### PR TITLE
Fix getGroup lookup

### DIFF
--- a/extension/src/tabstronautDataProvider.ts
+++ b/extension/src/tabstronautDataProvider.ts
@@ -207,8 +207,27 @@ export class TabstronautDataProvider
   }
 
   getGroup(groupName: string): Group | undefined {
-    const groups = this.workspaceState.get<Group[]>("tabGroups", []);
-    return groups.find((group) => group.label === groupName);
+    const tabGroups = this.workspaceState.get<{
+      [id: string]: {
+        label: string;
+        items: string[];
+        creationTime?: string;
+        colorName?: string;
+      };
+    }>("tabGroups", {});
+
+    for (const id in tabGroups) {
+      const g = tabGroups[id];
+      if (g.label === groupName) {
+        const creationTime = g.creationTime
+          ? new Date(g.creationTime)
+          : new Date();
+        const group = new Group(g.label, id, creationTime, g.colorName);
+        g.items.forEach((filePath) => group.addItem(filePath));
+        return group;
+      }
+    }
+    return undefined;
   }
 
   public getGroups(): Group[] {

--- a/extension/test/suite/tabstronautDataProvider.test.ts
+++ b/extension/test/suite/tabstronautDataProvider.test.ts
@@ -1,0 +1,46 @@
+import { strictEqual, ok } from 'assert';
+import * as vscode from 'vscode';
+import { TabstronautDataProvider } from '../../src/tabstronautDataProvider';
+
+class MockMemento implements vscode.Memento {
+  private store: Record<string, any>;
+  constructor(initial: Record<string, any> = {}) {
+    this.store = initial;
+  }
+  get<T>(key: string, defaultValue?: T): T {
+    if (key in this.store) {
+      return this.store[key] as T;
+    }
+    return defaultValue as T;
+  }
+  update(key: string, value: any): Thenable<void> {
+    this.store[key] = value;
+    return Promise.resolve();
+  }
+}
+
+describe('TabstronautDataProvider.getGroup', () => {
+  it('returns the group matching the given label', () => {
+    const tabGroups = {
+      '1': {
+        label: 'Work',
+        items: ['/tmp/file1'],
+        creationTime: new Date().toISOString(),
+        colorName: 'terminal.ansiRed',
+      },
+      '2': {
+        label: 'Play',
+        items: [],
+        creationTime: new Date().toISOString(),
+        colorName: 'terminal.ansiBlue',
+      },
+    };
+    const memento = new MockMemento({ tabGroups });
+    const provider = new TabstronautDataProvider(memento);
+    const group = provider.getGroup('Work');
+    provider.clearRefreshInterval();
+    ok(group, 'Expected group to be defined');
+    strictEqual(group?.label, 'Work');
+    strictEqual(group?.items.length, 1);
+  });
+});

--- a/extension/test/suite/tabstronautDataProvider.test.ts
+++ b/extension/test/suite/tabstronautDataProvider.test.ts
@@ -7,6 +7,9 @@ class MockMemento implements vscode.Memento {
   constructor(initial: Record<string, any> = {}) {
     this.store = initial;
   }
+  keys(): readonly string[] {
+    throw new Error('Method not implemented.');
+  }
   get<T>(key: string, defaultValue?: T): T {
     if (key in this.store) {
       return this.store[key] as T;


### PR DESCRIPTION
## Summary
- fix `getGroup` implementation to properly read tab groups object
- add unit test for `getGroup`

## Testing
- `npm test` *(fails: Cannot find type definition file for 'mocha')*

------
https://chatgpt.com/codex/tasks/task_e_6843dc62eb0083249ad9b12c3c4080d4