### PR TITLE
Enable command palette add-to-group

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,12 @@ For a detailed list of all updates in bullet point format, see our [Change Log](
 ---
 
 **Enjoy using Tabstronaut!** 🧑‍🚀🪐
+
+## Development & Testing
+
+To run the unit tests locally:
+
+1. Install dependencies with `npm install` inside the `extension` folder.
+2. Run `npm test` from the same folder.
+
+The test suite requires Node and VS Code type definitions which are installed through the development dependencies.

--- a/extension/package.json
+++ b/extension/package.json
@@ -243,8 +243,7 @@
       ],
       "commandPalette": [
         {
-          "command": "tabstronaut.openTabGroupContextMenu",
-          "when": "false"
+          "command": "tabstronaut.openTabGroupContextMenu"
         },
         {
           "command": "tabstronaut.openTabGroupContextMenuFromEditorTabRightClick",

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -344,7 +344,7 @@ export function activate(context: vscode.ExtensionContext) {
           !("uri" in activeTab.input)
         ) {
           vscode.window.showWarningMessage(
-            "No supported file tab selected to add to a Tab Group."
+            "Add to Tab Group is only available when an editor tab is active."
           );
           return;
         }


### PR DESCRIPTION
## Summary
- re-enable the `Add to Tab Group...` command in the palette
- show a clearer warning when no editor tab is active
- document how to run tests locally

## Testing
- `npm test` *(fails: Cannot find type definition file for 'mocha')*

------
https://chatgpt.com/codex/tasks/task_e_6843e44771cc8324b2633d5642dabca7