### PR TITLE
Improve message consistency

### DIFF
--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -152,7 +152,7 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(
       "tabstronaut.openTabGroupContextMenuFromEditorTabRightClick",
       async (contextSelection: vscode.Uri) => {
-        const INVALID_TAB_MESSAGE = `Can't add this selection to a Tab Group. Please ensure you're selecting a valid source code file tab.`;
+        const INVALID_TAB_MESSAGE = `Cannot add this selection to a Tab Group. Please ensure you select a valid source code file tab.`;
         const filePath = contextSelection.fsPath;
 
         try {
@@ -233,7 +233,7 @@ export function activate(context: vscode.ExtensionContext) {
               await openFileSmart(filePath);
             } catch {
               vscode.window.showErrorMessage(
-                `Failed to open '${path.basename(
+                `Cannot open '${path.basename(
                   filePath
                 )}'. Please check if the file exists and try again.`
               );
@@ -269,7 +269,7 @@ export function activate(context: vscode.ExtensionContext) {
               await openFileSmart(filePath);
             } catch {
               vscode.window.showErrorMessage(
-                `Failed to open '${path.basename(
+                `Cannot open '${path.basename(
                   filePath
                 )}'. Please check if the file exists and try again.`
               );
@@ -559,7 +559,7 @@ export function activate(context: vscode.ExtensionContext) {
       );
 
       if (!restored) {
-        vscode.window.showErrorMessage("Failed to restore Tab Group.");
+        vscode.window.showErrorMessage("Cannot restore Tab Group.");
         return;
       }
 

--- a/extension/src/fileOperations.ts
+++ b/extension/src/fileOperations.ts
@@ -25,7 +25,7 @@ export async function handleOpenTab(item: any, fromButton: boolean) {
       await vscode.window.showTextDocument(doc, { preview });
     }
   } catch {
-    vscode.window.showErrorMessage(`Failed to open '${path.basename(uri.fsPath)}'.`);
+    vscode.window.showErrorMessage(`Cannot open '${path.basename(uri.fsPath)}'.`);
   }
 }
 
@@ -44,7 +44,7 @@ export async function openFileSmart(filePath: string): Promise<void> {
     }
   } catch {
     vscode.window.showErrorMessage(
-      `Failed to open '${path.basename(filePath)}'. Please check if the file exists and try again.`
+      `Cannot open '${path.basename(filePath)}'. Please check if the file exists and try again.`
     );
   }
 }

--- a/extension/src/groupOperations.ts
+++ b/extension/src/groupOperations.ts
@@ -230,7 +230,7 @@ export async function handleNewGroupCreation(
   const groupId = await treeDataProvider.addGroup(result.name, groupColor);
   if (!groupId) {
     vscode.window.showErrorMessage(
-      `Failed to create Tab Group with name: ${result.name}.`
+      `Cannot create Tab Group with name: ${result.name}.`
     );
     return;
   }

--- a/extension/src/models/Group.ts
+++ b/extension/src/models/Group.ts
@@ -38,7 +38,7 @@ export class Group extends vscode.TreeItem {
 
     addItem(filePath: string) {
         if (!filePath) {
-            vscode.window.showErrorMessage(`Can't interpret file path. You may need to delete the Tab Group and try again.`);
+            vscode.window.showErrorMessage(`Cannot interpret file path. You may need to delete the Tab Group and try again.`);
             return;
         }
         this.items.push(this.createTabItem(filePath));

--- a/extension/src/tabstronautDataProvider.ts
+++ b/extension/src/tabstronautDataProvider.ts
@@ -556,7 +556,7 @@ export class TabstronautDataProvider
     const content = JSON.stringify(groupData, null, 2);
 
     await vscode.workspace.fs.writeFile(uri, Buffer.from(content, "utf8"));
-    showConfirmation("Tab Groups exported successfully!");
+    showConfirmation("Tab Groups exported successfully.");
   }
 
   async importGroupsFromFile(): Promise<void> {
@@ -604,10 +604,10 @@ export class TabstronautDataProvider
       await this.workspaceState.update("tabGroups", mergedGroups);
       this.rebuildStateFromStorage();
       this.refresh();
-      showConfirmation("Tab Groups imported successfully!");
+      showConfirmation("Tab Groups imported successfully.");
     } catch (error) {
       vscode.window.showErrorMessage(
-        "Failed to import Tab Groups. Invalid JSON file."
+        "Cannot import Tab Groups. Invalid JSON file."
       );
     }
   }


### PR DESCRIPTION
## Summary
- standardize error and info messages
- use present tense and consistent punctuation

## Testing
- `npm test` *(fails: Cannot find type definition file for 'mocha')*

------
https://chatgpt.com/codex/tasks/task_e_68443334e680832498255d9a6278d7c1