### PR TITLE
Update changelog for v1.2.5

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the Tabstronaut extension will be documented in this file.
 
+## [1.2.5]
+
+- Add unit tests.
+- Fix two issues with importing Tabs — colors and locating the correct group.
+- Restored context menu command (`Ctrl+Shift+P`) to open the Tab Group context menu.
+- Code cleanup with more classes and separation of concerns.
+- Restoring a Tab Group returns it to its original position instead of moving it to the top.
+- Added buttons for selecting defaults when creating a Tab Group.
+- Improved text consistency throughout the extension.
+
 ## [1.2.4]
 
 - Disable erroneous commands


### PR DESCRIPTION
## Summary
- document v1.2.5 changes in the changelog

## Testing
- `npm test` *(fails: Cannot find type definition file for 'mocha')*

------
https://chatgpt.com/codex/tasks/task_e_684434ea46108324bc12c9b26e7dbb1f