### PR TITLE
Improve drag-and-drop reordering

### DIFF
--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -34,6 +34,7 @@ export function activate(context: vscode.ExtensionContext) {
       previousGroupId: prevId,
       createTabItem: group.createTabItem.bind(group),
       addItem: group.addItem.bind(group),
+      containsFile: group.containsFile.bind(group),
     };
 
     vscode.commands.executeCommand(
@@ -320,6 +321,7 @@ export function activate(context: vscode.ExtensionContext) {
           previousGroupId: prevId,
           createTabItem: group.createTabItem.bind(group),
           addItem: group.addItem.bind(group),
+          containsFile: group.containsFile.bind(group),
         };
         treeDataProvider.deleteGroup(group.id);
 

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -227,7 +227,7 @@ export function activate(context: vscode.ExtensionContext) {
         }
 
         for (const tabItem of group.items) {
-          const filePath = tabItem.resourceUri?.path;
+          const filePath = tabItem.resourceUri?.fsPath;
           if (filePath) {
             try {
               await openFileSmart(filePath);
@@ -263,7 +263,7 @@ export function activate(context: vscode.ExtensionContext) {
         }
 
         for (const tabItem of group.items) {
-          const filePath = tabItem.resourceUri?.path;
+          const filePath = tabItem.resourceUri?.fsPath;
           if (filePath) {
             try {
               await openFileSmart(filePath);
@@ -375,7 +375,7 @@ export function activate(context: vscode.ExtensionContext) {
           return;
         }
 
-        treeDataProvider.removeFromGroup(item.groupId, item.resourceUri?.path);
+        treeDataProvider.removeFromGroup(item.groupId, item.resourceUri?.fsPath);
       }
     )
   );

--- a/extension/src/models/Group.ts
+++ b/extension/src/models/Group.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { generateRelativeTime, generateRelativeDescription, generateColorHash, COLORS } from '../utils';
+import { generateRelativeTime, generateRelativeDescription, generateColorHash, COLORS, generateNormalizedPath } from '../utils';
 
 export class Group extends vscode.TreeItem {
     items: TabItem[] = [];
@@ -34,6 +34,14 @@ export class Group extends vscode.TreeItem {
             arguments: [item]
         };
         return item;
+    }
+
+    containsFile(filePath: string): boolean {
+        const normalized = generateNormalizedPath(filePath);
+        return this.items.some(
+            (i) =>
+                generateNormalizedPath(i.resourceUri?.fsPath || '') === normalized
+        );
     }
 
     addItem(filePath: string) {

--- a/extension/src/models/Group.ts
+++ b/extension/src/models/Group.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { generateRelativeTime, generateRelativeDescription, generateColorHash, COLORS } from '../utils';
 
 export class Group extends vscode.TreeItem {
-    items: vscode.TreeItem[] = [];
+    items: TabItem[] = [];
     id: string;
     creationTime: Date;
     colorName: string;
@@ -45,6 +45,6 @@ export class Group extends vscode.TreeItem {
     }
 }
 
-class TabItem extends vscode.TreeItem {
+export class TabItem extends vscode.TreeItem {
     groupId?: string;
 }

--- a/extension/src/tabstronautDataProvider.ts
+++ b/extension/src/tabstronautDataProvider.ts
@@ -128,6 +128,20 @@ export class TabstronautDataProvider
           return;
         }
 
+        const normalizedPath = generateNormalizedPath(
+          tab.resourceUri?.path || ""
+        );
+        const duplicate = target.items.some(
+          (i) =>
+            generateNormalizedPath(i.resourceUri?.path || "") === normalizedPath
+        );
+        if (duplicate) {
+          vscode.window.showWarningMessage(
+            `'${tab.label}' is already in Tab Group '${target.label}'.`
+          );
+          continue;
+        }
+
         sourceGroup.items = sourceGroup.items.filter((i) => i.id !== tabId);
         tab.groupId = target.id;
         target.items.push(tab);
@@ -159,6 +173,20 @@ export class TabstronautDataProvider
         }
 
         const targetIndex = targetGroup.items.findIndex((i) => i.id === targetTabId);
+
+        const normalizedPath = generateNormalizedPath(
+          draggedTab.resourceUri?.path || ""
+        );
+        const duplicate = targetGroup.items.some(
+          (i) =>
+            generateNormalizedPath(i.resourceUri?.path || "") === normalizedPath
+        );
+        if (duplicate && targetGroup !== sourceGroup) {
+          vscode.window.showWarningMessage(
+            `'${draggedTab.label}' is already in Tab Group '${targetGroup.label}'.`
+          );
+          continue;
+        }
 
         sourceGroup.items = sourceGroup.items.filter((i) => i.id !== tabId);
         if (targetGroup === sourceGroup) {

--- a/extension/src/tabstronautDataProvider.ts
+++ b/extension/src/tabstronautDataProvider.ts
@@ -128,7 +128,12 @@ export class TabstronautDataProvider
           return;
         }
 
-        const duplicate = target.containsFile(tab.resourceUri?.fsPath || "");
+        const tabPath = tab.resourceUri?.fsPath || "";
+        const duplicate = target.items.some(
+          (i) =>
+            generateNormalizedPath(i.resourceUri?.fsPath || "") ===
+            generateNormalizedPath(tabPath)
+        );
         if (duplicate) {
           vscode.window.showWarningMessage(
             `'${tab.label}' is already in Tab Group '${target.label}'.`
@@ -169,8 +174,11 @@ export class TabstronautDataProvider
 
         const targetIndex = targetGroup.items.findIndex((i) => i.id === targetTabId);
 
-        const duplicate = targetGroup.containsFile(
-          draggedTab.resourceUri?.fsPath || ""
+        const draggedPath = draggedTab.resourceUri?.fsPath || "";
+        const duplicate = targetGroup.items.some(
+          (i) =>
+            generateNormalizedPath(i.resourceUri?.fsPath || "") ===
+            generateNormalizedPath(draggedPath)
         );
         if (duplicate && targetGroup !== sourceGroup) {
           vscode.window.showWarningMessage(

--- a/extension/src/tabstronautDataProvider.ts
+++ b/extension/src/tabstronautDataProvider.ts
@@ -129,11 +129,11 @@ export class TabstronautDataProvider
         }
 
         const normalizedPath = generateNormalizedPath(
-          tab.resourceUri?.path || ""
+          tab.resourceUri?.fsPath || ""
         );
         const duplicate = target.items.some(
           (i) =>
-            generateNormalizedPath(i.resourceUri?.path || "") === normalizedPath
+            generateNormalizedPath(i.resourceUri?.fsPath || "") === normalizedPath
         );
         if (duplicate) {
           vscode.window.showWarningMessage(
@@ -175,11 +175,11 @@ export class TabstronautDataProvider
         const targetIndex = targetGroup.items.findIndex((i) => i.id === targetTabId);
 
         const normalizedPath = generateNormalizedPath(
-          draggedTab.resourceUri?.path || ""
+          draggedTab.resourceUri?.fsPath || ""
         );
         const duplicate = targetGroup.items.some(
           (i) =>
-            generateNormalizedPath(i.resourceUri?.path || "") === normalizedPath
+            generateNormalizedPath(i.resourceUri?.fsPath || "") === normalizedPath
         );
         if (duplicate && targetGroup !== sourceGroup) {
           vscode.window.showWarningMessage(
@@ -353,7 +353,7 @@ export class TabstronautDataProvider
 
     const existingItem = group.items.find(
       (item) =>
-        generateNormalizedPath(item.resourceUri?.path || "") ===
+        generateNormalizedPath(item.resourceUri?.fsPath || "") ===
         normalizedFilePath
     );
 
@@ -420,7 +420,7 @@ export class TabstronautDataProvider
       const items = [...group.items];
       group.items = [];
       items.forEach((itemPath) =>
-        group.addItem(itemPath.resourceUri?.path as string)
+        group.addItem(itemPath.resourceUri?.fsPath as string)
       );
     });
 
@@ -474,7 +474,7 @@ export class TabstronautDataProvider
   
     const isLastTab =
       group.items.length === 1 &&
-      group.items[0].resourceUri?.path === filePath;
+      group.items[0].resourceUri?.fsPath === filePath;
   
     if (isLastTab && shouldConfirm) {
       const shouldDelete: string | undefined = await vscode.window.showQuickPick(
@@ -501,7 +501,7 @@ export class TabstronautDataProvider
     }
   
     group.items = group.items.filter(
-      (item) => item.resourceUri?.path !== filePath
+      (item) => item.resourceUri?.fsPath !== filePath
     );
   
     const shouldMoveGroup = vscode.workspace
@@ -541,7 +541,7 @@ export class TabstronautDataProvider
     } = {};
     this.groupsMap.forEach((group, id) => {
       if (typeof group.label === "string") {
-        let items = group.items.map((item) => item.resourceUri?.path as string);
+        let items = group.items.map((item) => item.resourceUri?.fsPath as string);
         groupData[id] = {
           label: group.label,
           items: items,
@@ -565,7 +565,7 @@ export class TabstronautDataProvider
     this.groupsMap.forEach((group) => {
       for (let i = 0; i < group.items.length; i++) {
         const item = group.items[i];
-        const itemPath = item.resourceUri?.path;
+        const itemPath = item.resourceUri?.fsPath;
 
         if (
           itemPath &&

--- a/extension/src/tabstronautDataProvider.ts
+++ b/extension/src/tabstronautDataProvider.ts
@@ -481,11 +481,12 @@ export class TabstronautDataProvider
     }
   
     if (isLastTab && this.onGroupAutoDeleted) {
-      const backupGroup = {
+      const backupGroup: Group = {
         ...group,
         items: [...group.items],
         createTabItem: group.createTabItem.bind(group),
         addItem: group.addItem.bind(group),
+        containsFile: group.containsFile.bind(group),
       };
       this.onGroupAutoDeleted(backupGroup);
     }

--- a/extension/src/tabstronautDataProvider.ts
+++ b/extension/src/tabstronautDataProvider.ts
@@ -138,6 +138,7 @@ export class TabstronautDataProvider
 
         sourceGroup.items = sourceGroup.items.filter((i) => i.id !== tabId);
         tab.groupId = target.id;
+        tab.id = target.id + (tab.resourceUri?.fsPath || "");
         target.items.push(tab);
 
         this.refresh();
@@ -184,6 +185,7 @@ export class TabstronautDataProvider
           targetGroup.items.splice(adjustedIndex, 0, draggedTab);
         } else {
           draggedTab.groupId = targetGroup.id;
+          draggedTab.id = targetGroup.id + (draggedTab.resourceUri?.fsPath || "");
           targetGroup.items.splice(targetIndex, 0, draggedTab);
         }
 

--- a/extension/src/tabstronautDataProvider.ts
+++ b/extension/src/tabstronautDataProvider.ts
@@ -128,13 +128,7 @@ export class TabstronautDataProvider
           return;
         }
 
-        const normalizedPath = generateNormalizedPath(
-          tab.resourceUri?.fsPath || ""
-        );
-        const duplicate = target.items.some(
-          (i) =>
-            generateNormalizedPath(i.resourceUri?.fsPath || "") === normalizedPath
-        );
+        const duplicate = target.containsFile(tab.resourceUri?.fsPath || "");
         if (duplicate) {
           vscode.window.showWarningMessage(
             `'${tab.label}' is already in Tab Group '${target.label}'.`
@@ -174,12 +168,8 @@ export class TabstronautDataProvider
 
         const targetIndex = targetGroup.items.findIndex((i) => i.id === targetTabId);
 
-        const normalizedPath = generateNormalizedPath(
+        const duplicate = targetGroup.containsFile(
           draggedTab.resourceUri?.fsPath || ""
-        );
-        const duplicate = targetGroup.items.some(
-          (i) =>
-            generateNormalizedPath(i.resourceUri?.fsPath || "") === normalizedPath
         );
         if (duplicate && targetGroup !== sourceGroup) {
           vscode.window.showWarningMessage(

--- a/extension/src/tabstronautDataProvider.ts
+++ b/extension/src/tabstronautDataProvider.ts
@@ -95,31 +95,19 @@ export class TabstronautDataProvider
           return;
         }
 
-        const order = Array.from(this.groupsMap.keys());
-        const draggedIndex = order.indexOf(draggedGroup.id);
-        const targetIndex = order.indexOf(targetGroup.id);
+        const groups = Array.from(this.groupsMap.values());
+        const draggedIndex = groups.findIndex((g) => g.id === draggedGroup.id);
+        const targetIndex = groups.findIndex((g) => g.id === targetGroup.id);
 
         if (draggedIndex === -1 || targetIndex === -1) {
           return;
         }
 
-        order.splice(draggedIndex, 1);
-        const adjustedTargetIndex = order.indexOf(targetGroup.id);
-        if (adjustedTargetIndex === -1) {
-          return;
-        }
-        order.splice(adjustedTargetIndex, 0, draggedGroup.id);
+        groups.splice(draggedIndex, 1);
+        const insertIndex = groups.findIndex((g) => g.id === targetGroup.id);
+        groups.splice(insertIndex, 0, draggedGroup);
 
-        const reordered = new Map<string, Group>();
-        for (const key of order) {
-          if (key === draggedGroup.id) {
-            reordered.set(key, draggedGroup);
-          } else {
-            reordered.set(key, this.groupsMap.get(key)!);
-          }
-        }
-
-        this.groupsMap = reordered;
+        this.groupsMap = new Map(groups.map((g) => [g.id, g]));
         this.refresh();
         await this.updateWorkspaceState();
         showConfirmation(`Reordered Tab Group '${draggedGroup.label}'.`);

--- a/extension/src/tabstronautDataProvider.ts
+++ b/extension/src/tabstronautDataProvider.ts
@@ -129,11 +129,7 @@ export class TabstronautDataProvider
         }
 
         const tabPath = tab.resourceUri?.fsPath || "";
-        const duplicate = target.items.some(
-          (i) =>
-            generateNormalizedPath(i.resourceUri?.fsPath || "") ===
-            generateNormalizedPath(tabPath)
-        );
+        const duplicate = target.containsFile(tabPath);
         if (duplicate) {
           vscode.window.showWarningMessage(
             `'${tab.label}' is already in Tab Group '${target.label}'.`
@@ -175,11 +171,7 @@ export class TabstronautDataProvider
         const targetIndex = targetGroup.items.findIndex((i) => i.id === targetTabId);
 
         const draggedPath = draggedTab.resourceUri?.fsPath || "";
-        const duplicate = targetGroup.items.some(
-          (i) =>
-            generateNormalizedPath(i.resourceUri?.fsPath || "") ===
-            generateNormalizedPath(draggedPath)
-        );
+        const duplicate = targetGroup.containsFile(draggedPath);
         if (duplicate && targetGroup !== sourceGroup) {
           vscode.window.showWarningMessage(
             `'${draggedTab.label}' is already in Tab Group '${targetGroup.label}'.`

--- a/extension/src/tabstronautDataProvider.ts
+++ b/extension/src/tabstronautDataProvider.ts
@@ -104,9 +104,11 @@ export class TabstronautDataProvider
         }
 
         order.splice(draggedIndex, 1);
-
-        const insertIndex = draggedIndex < targetIndex ? targetIndex - 1 : targetIndex;
-        order.splice(insertIndex, 0, draggedGroup.id);
+        const adjustedTargetIndex = order.indexOf(targetGroup.id);
+        if (adjustedTargetIndex === -1) {
+          return;
+        }
+        order.splice(adjustedTargetIndex, 0, draggedGroup.id);
 
         const reordered = new Map<string, Group>();
         for (const key of order) {
@@ -129,7 +131,9 @@ export class TabstronautDataProvider
           g.items.some((i) => i.id === tabId)
         );
 
-        const tab = sourceGroup?.items.find((i) => i.id === tabId);
+        const tab = sourceGroup?.items.find((i) => i.id === tabId) as
+          | TabItem
+          | undefined;
         if (!tab || !sourceGroup) {
           return;
         }
@@ -149,7 +153,9 @@ export class TabstronautDataProvider
         const sourceGroup = Array.from(this.groupsMap.values()).find((g) =>
           g.items.some((i) => i.id === tabId)
         );
-        const draggedTab = sourceGroup?.items.find((i) => i.id === tabId);
+        const draggedTab = sourceGroup?.items.find((i) => i.id === tabId) as
+          | TabItem
+          | undefined;
         if (!draggedTab || !sourceGroup) {
           return;
         }

--- a/extension/src/tabstronautDataProvider.ts
+++ b/extension/src/tabstronautDataProvider.ts
@@ -88,25 +88,26 @@ export class TabstronautDataProvider
     for (const id of draggedIds) {
       if (id.startsWith("group:")) {
         const groupId = id.replace("group:", "");
-        const groupOrder = Array.from(this.groupsMap.keys());
         const draggedGroup = this.groupsMap.get(groupId);
         const targetGroup = target instanceof Group ? target : undefined;
 
-        if (
-          !draggedGroup ||
-          !targetGroup ||
-          draggedGroup.id === targetGroup.id
-        ) {
+        if (!draggedGroup || !targetGroup || draggedGroup.id === targetGroup.id) {
           return;
         }
 
         this.groupsMap.delete(groupId);
+        const order = Array.from(this.groupsMap.keys());
+        let targetIndex = order.indexOf(targetGroup.id);
+        if (targetIndex === -1) {
+          targetIndex = order.length;
+        }
+        order.splice(targetIndex, 0, draggedGroup.id);
+
         const reordered = new Map<string, Group>();
-        for (const key of groupOrder) {
-          if (key === targetGroup.id) {
-            reordered.set(draggedGroup.id, draggedGroup);
-          }
-          if (this.groupsMap.has(key)) {
+        for (const key of order) {
+          if (key === draggedGroup.id) {
+            reordered.set(key, draggedGroup);
+          } else {
             reordered.set(key, this.groupsMap.get(key)!);
           }
         }
@@ -114,6 +115,7 @@ export class TabstronautDataProvider
         this.groupsMap = reordered;
         this.refresh();
         await this.updateWorkspaceState();
+        showConfirmation(`Reordered Tab Group '${draggedGroup.label}'.`);
       }
 
       if (id.startsWith("tab:") && target instanceof Group) {

--- a/extension/src/tabstronautDataProvider.ts
+++ b/extension/src/tabstronautDataProvider.ts
@@ -95,13 +95,18 @@ export class TabstronautDataProvider
           return;
         }
 
-        this.groupsMap.delete(groupId);
         const order = Array.from(this.groupsMap.keys());
-        let targetIndex = order.indexOf(targetGroup.id);
-        if (targetIndex === -1) {
-          targetIndex = order.length;
+        const draggedIndex = order.indexOf(draggedGroup.id);
+        const targetIndex = order.indexOf(targetGroup.id);
+
+        if (draggedIndex === -1 || targetIndex === -1) {
+          return;
         }
+
+        order.splice(draggedIndex, 1);
         order.splice(targetIndex, 0, draggedGroup.id);
+
+        this.groupsMap.delete(groupId);
 
         const reordered = new Map<string, Group>();
         for (const key of order) {

--- a/extension/src/tabstronautDataProvider.ts
+++ b/extension/src/tabstronautDataProvider.ts
@@ -104,8 +104,10 @@ export class TabstronautDataProvider
         }
 
         groups.splice(draggedIndex, 1);
-        const insertIndex = groups.findIndex((g) => g.id === targetGroup.id);
-        groups.splice(insertIndex, 0, draggedGroup);
+        const insertPos = groups.findIndex((g) => g.id === targetGroup.id);
+        const adjustedIndex =
+          draggedIndex < targetIndex ? insertPos + 1 : insertPos;
+        groups.splice(adjustedIndex, 0, draggedGroup);
 
         this.groupsMap = new Map(groups.map((g) => [g.id, g]));
         this.refresh();

--- a/extension/src/tabstronautDataProvider.ts
+++ b/extension/src/tabstronautDataProvider.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import * as path from "path";
-import { Group } from "./models/Group";
+import { Group, TabItem } from "./models/Group";
 import {
   generateUuidv4,
   generateRelativeTime,

--- a/extension/src/tabstronautDataProvider.ts
+++ b/extension/src/tabstronautDataProvider.ts
@@ -104,9 +104,9 @@ export class TabstronautDataProvider
         }
 
         order.splice(draggedIndex, 1);
-        order.splice(targetIndex, 0, draggedGroup.id);
 
-        this.groupsMap.delete(groupId);
+        const insertIndex = draggedIndex < targetIndex ? targetIndex - 1 : targetIndex;
+        order.splice(insertIndex, 0, draggedGroup.id);
 
         const reordered = new Map<string, Group>();
         for (const key of order) {


### PR DESCRIPTION
## Summary
- allow reordering individual tabs inside a group by dropping onto another tab

## Testing
- `npm test` *(fails: Cannot find type definition file for 'mocha')*

------
https://chatgpt.com/codex/tasks/task_e_68448e9789988324bb0150b3b0efddb2