### PR TITLE
Implement group creation by dropping tab on empty area

### DIFF
--- a/extension/test/suite/tabstronautDataProvider.test.ts
+++ b/extension/test/suite/tabstronautDataProvider.test.ts
@@ -117,4 +117,21 @@ describe('TabstronautDataProvider basic operations', () => {
     strictEqual(provider.getGroups().some((g) => g.id === g1), false);
     strictEqual(dstGroup.items.length, 1);
   });
+
+  it('handleDrop creates new group when dropping file on empty space', async () => {
+    const memento = new MockMemento({});
+    const provider = new TabstronautDataProvider(memento);
+
+    const uri = vscode.Uri.file('/tmp/file2');
+    const dragData = new vscode.DataTransfer();
+    dragData.set('text/uri-list', new vscode.DataTransferItem(uri.toString()));
+
+    await provider.handleDrop(undefined, dragData, new vscode.CancellationTokenSource().token);
+
+    provider.clearRefreshInterval();
+    const groups = provider.getGroups();
+    strictEqual(groups.length, 1);
+    strictEqual(groups[0].items.length, 1);
+    strictEqual(groups[0].items[0].resourceUri?.fsPath, uri.fsPath);
+  });
 });


### PR DESCRIPTION
## Summary
- support creating a new tab group when a file is dropped on empty space
- test new drop behaviour

## Testing
- `npm test` *(fails: Cannot find type definition file for 'mocha')*

------
https://chatgpt.com/codex/tasks/task_e_6844c0b511e08324878c13ba3b875f44