### PR TITLE
Fix drag and drop with comma filenames

### DIFF
--- a/extension/src/tabstronautDataProvider.ts
+++ b/extension/src/tabstronautDataProvider.ts
@@ -71,7 +71,7 @@ export class TabstronautDataProvider
 
     dataTransfer.set(
       "application/vnd.code.tree.tabstronaut",
-      new vscode.DataTransferItem(ids.join(","))
+      new vscode.DataTransferItem(JSON.stringify(ids))
     );
   }
 
@@ -111,7 +111,18 @@ export class TabstronautDataProvider
       return;
     }
 
-    const draggedIds = (transferItem.value as string).split(",");
+    let draggedIds: string[] = [];
+    const raw = transferItem.value as string;
+    try {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        draggedIds = parsed as string[];
+      } else {
+        draggedIds = raw.split(",");
+      }
+    } catch {
+      draggedIds = raw.split(",");
+    }
 
     for (const id of draggedIds) {
       if (id.startsWith("group:")) {

--- a/extension/test/suite/tabstronautDataProvider.test.ts
+++ b/extension/test/suite/tabstronautDataProvider.test.ts
@@ -117,6 +117,37 @@ describe('TabstronautDataProvider basic operations', () => {
     strictEqual(provider.getGroups().some((g) => g.id === g1), false);
     strictEqual(dstGroup.items.length, 1);
   });
+
+  it('handles file paths containing commas when dragging tabs', async () => {
+    const memento = new MockMemento({});
+    const provider = new TabstronautDataProvider(memento);
+
+    const g1 = await provider.addGroup('G1');
+    const g2 = await provider.addGroup('G2');
+    const file = '/tmp/.NETCoreApp,Version=v7.0.AssemblyAttributes.cs';
+    await provider.addToGroup(g1!, file);
+
+    const srcGroup = provider.getGroup('G1')!;
+    const dstGroup = provider.getGroup('G2')!;
+    const tabItem = srcGroup.items[0];
+
+    const dragData = new vscode.DataTransfer();
+    await provider.handleDrag(
+      [tabItem],
+      dragData,
+      new vscode.CancellationTokenSource().token
+    );
+    await provider.handleDrop(
+      dstGroup,
+      dragData,
+      new vscode.CancellationTokenSource().token
+    );
+
+    provider.clearRefreshInterval();
+    strictEqual(provider.getGroups().some((g) => g.id === g1), false);
+    strictEqual(dstGroup.items.length, 1);
+    strictEqual(dstGroup.items[0].resourceUri?.fsPath, file);
+  });
 });
 
 describe('TabstronautDataProvider.sortGroup', () => {


### PR DESCRIPTION
## Summary
- fix TabstronautDataProvider drag and drop payload encoding
- add regression test for comma-containing filenames

## Testing
- `npm test` *(fails: Cannot find type definition file for 'mocha')*

------
https://chatgpt.com/codex/tasks/task_e_6847530527d4832496e2e15f8026bd60