### PR TITLE
Remove unused explorer option

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -130,11 +130,6 @@
         "title": "Import Tab Groups from JSON"
       },
       {
-        "command": "tabstronaut.addFilesToGroup",
-        "category": "Tabstronaut",
-        "title": "Add to Tab Group..."
-      },
-      {
         "command": "tabstronaut.addAllOpenTabsToGroup",
         "category": "Tabstronaut",
         "title": "Add all tabs to Tab Group",
@@ -190,13 +185,6 @@
           "command": "tabstronaut.showMoreOptions",
           "when": "view == tabstronaut",
           "group": "navigation@3"
-        }
-      ],
-      "explorer/context": [
-        {
-          "command": "tabstronaut.addFilesToGroup",
-          "when": "resourceLangId != ''",
-          "group": "3_tabstronaut"
         }
       ],
       "editor/title/context": [
@@ -310,10 +298,6 @@
         },
         {
           "command": "tabstronaut.importTabGroups",
-          "when": "false"
-        },
-        {
-          "command": "tabstronaut.addFilesToGroup",
           "when": "false"
         },
         {

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -8,7 +8,6 @@ import {
   handleTabGroupAction,
   renameTabGroupCommand,
   addAllOpenTabsToGroup,
-  addFilesToGroupCommand,
   sortTabGroupCommand,
 } from "./groupOperations";
 
@@ -534,15 +533,6 @@ export function activate(context: vscode.ExtensionContext) {
     )
   );
 
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      "tabstronaut.addFilesToGroup",
-      async (uri: vscode.Uri, uris?: vscode.Uri[]) => {
-        const allUris = uris && uris.length > 1 ? uris : [uri];
-        await addFilesToGroupCommand(treeDataProvider, allUris);
-      }
-    )
-  );
 
 
 

--- a/extension/src/groupOperations.ts
+++ b/extension/src/groupOperations.ts
@@ -2,7 +2,6 @@ import * as vscode from 'vscode';
 import { TabstronautDataProvider } from './tabstronautDataProvider';
 import { Group } from './models/Group';
 import { COLORS, COLOR_LABELS, showConfirmation } from './utils';
-import { gatherFileUris } from './fileOperations';
 
 export type GroupNameResult = {
   name: string | undefined;
@@ -423,46 +422,6 @@ export async function addAllOpenTabsToGroup(
   showConfirmation(`Added ${count} open tab(s) to Tab Group '${group.label}'.`);
 }
 
-export async function addFilesToGroupCommand(
-  treeDataProvider: TabstronautDataProvider,
-  uris: vscode.Uri[]
-): Promise<void> {
-  const fileUris = await gatherFileUris(uris);
-
-  if (fileUris.length === 0) {
-    showConfirmation('No files found to add to Tab Group.');
-    return;
-  }
-
-  const selectedGroup = await selectTabGroup(treeDataProvider);
-  if (!selectedGroup) {
-    return;
-  }
-
-  if (
-    selectedGroup.label === 'New Tab Group from current tab...' ||
-    selectedGroup.label === 'New Tab Group from all tabs...'
-  ) {
-    await handleNewGroupCreationFromMultipleFiles(
-      treeDataProvider,
-      selectedGroup.label,
-      fileUris
-    );
-    return;
-  }
-
-  if (!selectedGroup.id) {
-    return;
-  }
-
-  for (const file of fileUris) {
-    await treeDataProvider.addToGroup(selectedGroup.id, file.fsPath);
-  }
-
-  showConfirmation(
-    `Added ${fileUris.length} file(s) to Tab Group '${selectedGroup.label}'.`
-  );
-}
 
 export async function sortTabGroupCommand(
   treeDataProvider: TabstronautDataProvider,


### PR DESCRIPTION
## Summary
- remove the Add to Tab Group command from explorer menus
- drop supporting command implementation

## Testing
- `npm test` *(fails: Cannot find type definition file for 'mocha')*
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/parser')*


------
https://chatgpt.com/codex/tasks/task_e_6848b4e2404c832492533ce032c2a6b4