### PR TITLE
Fix explorer context menu add files behavior

### DIFF
--- a/extension/src/groupOperations.ts
+++ b/extension/src/groupOperations.ts
@@ -71,7 +71,8 @@ export type CustomQuickPickItem = vscode.QuickPickItem & {
 };
 
 export async function selectTabGroup(
-  treeDataProvider: TabstronautDataProvider
+  treeDataProvider: TabstronautDataProvider,
+  useSelectedFiles = false
 ): Promise<CustomQuickPickItem | undefined> {
   const quickPick = vscode.window.createQuickPick<CustomQuickPickItem>();
 
@@ -115,6 +116,11 @@ export async function selectTabGroup(
 
     quickPick.onDidTriggerItemButton(async (e) => {
       const item = e.item as CustomQuickPickItem;
+      if (useSelectedFiles) {
+        resolve(item);
+        quickPick.hide();
+        return;
+      }
 
       if (item.label === 'New Tab Group from current tab...') {
         const result = await getGroupNameForAllToNewGroup(treeDataProvider);
@@ -434,7 +440,7 @@ export async function addFilesToGroupCommand(
     return;
   }
 
-  const selectedGroup = await selectTabGroup(treeDataProvider);
+  const selectedGroup = await selectTabGroup(treeDataProvider, true);
   if (!selectedGroup) {
     return;
   }


### PR DESCRIPTION
## Summary
- ensure explorer context menu options add selected files instead of open tabs

## Testing
- `npm test` *(fails: Cannot find type definition file for 'mocha')*
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/parser')*

------
https://chatgpt.com/codex/tasks/task_e_6849da11b9008324a6deadd8b9e09648