### PR TITLE
Add alphabetical sort option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Tabstronaut excels in tab management for VS Code by enabling users to archive an
   - Collect your current or all open tabs into organized groups with a single click.
 - Drag-and-drop mastery
   - Effortlessly reorder tabs or entire groups and give them colors or timestamps to keep everything tidy.
+- Flexible sorting options
+  - Organize tabs alphabetically, by folder, or by file type within each group.
 - Share and revisit your workspaces
   - Save tab groups for later, export them to share, or bring back archived sets whenever inspiration strikes. 
 

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Tabstronaut extension will be documented in this file.
 
+## [1.3.2]
+
+- Added option to sort tabs alphabetically within a group.
+
 ## [1.3.1]
 
 - Fixed behavior with adding tabs from Solution Explorer.

--- a/extension/package.json
+++ b/extension/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/jhhtaylor/tabstronaut/issues",
     "email": "jhhtaylor@gmail.com"
   },
-  "version": "1.3.1",
+  "version": "1.3.2",
   "engines": {
     "vscode": "^1.99.0"
   },

--- a/extension/src/groupOperations.ts
+++ b/extension/src/groupOperations.ts
@@ -479,7 +479,7 @@ export async function sortTabGroupCommand(
   }
 
   const picked = await vscode.window.showQuickPick(
-    ['Sort by Folder', 'Sort by File Type'],
+    ['Sort by Folder', 'Sort by File Type', 'Sort Alphabetically'],
     { placeHolder: 'Sort Tab Group' }
   );
 
@@ -487,6 +487,11 @@ export async function sortTabGroupCommand(
     return;
   }
 
-  const mode = picked === 'Sort by File Type' ? 'fileType' : 'folder';
-  await treeDataProvider.sortGroup(item.id, mode as 'folder' | 'fileType');
+  let mode: 'folder' | 'fileType' | 'alphabetical' = 'folder';
+  if (picked === 'Sort by File Type') {
+    mode = 'fileType';
+  } else if (picked === 'Sort Alphabetically') {
+    mode = 'alphabetical';
+  }
+  await treeDataProvider.sortGroup(item.id, mode);
 }

--- a/extension/src/tabstronautDataProvider.ts
+++ b/extension/src/tabstronautDataProvider.ts
@@ -767,7 +767,7 @@ export class TabstronautDataProvider
 
   async sortGroup(
     groupId: string,
-    mode: "folder" | "fileType"
+    mode: "folder" | "fileType" | "alphabetical"
   ): Promise<void> {
     const group = this.groupsMap.get(groupId);
     if (!group) {
@@ -777,6 +777,9 @@ export class TabstronautDataProvider
     const getKey = (filePath: string): string => {
       if (mode === "fileType") {
         return path.extname(filePath).toLowerCase();
+      }
+      if (mode === "alphabetical") {
+        return path.basename(filePath).toLowerCase();
       }
       return labelForTopFolder(filePath).toLowerCase();
     };

--- a/extension/test/suite/tabstronautDataProvider.test.ts
+++ b/extension/test/suite/tabstronautDataProvider.test.ts
@@ -187,4 +187,16 @@ describe('TabstronautDataProvider.sortGroup', () => {
       configurable: true,
     });
   });
+
+  it('sorts alphabetically', async () => {
+    const provider = new TabstronautDataProvider(new MockMemento({}));
+    const id = await provider.addGroup('G1');
+    await provider.addToGroup(id!, '/tmp/b.ts');
+    await provider.addToGroup(id!, '/tmp/a.js');
+    await provider.sortGroup(id!, 'alphabetical');
+    provider.clearRefreshInterval();
+    const group = provider.getGroup('G1')!;
+    strictEqual(group.items[0].resourceUri?.fsPath, '/tmp/a.js');
+    strictEqual(group.items[1].resourceUri?.fsPath, '/tmp/b.ts');
+  });
 });


### PR DESCRIPTION
## Summary
- allow sorting a tab group alphabetically
- expose the alphabetical option in the sort picker
- document alphabetical sorting in README and CHANGELOG
- bump extension version to 1.3.2
- add unit test for alphabetical sorting

## Testing
- `npm test` *(fails: Cannot find type definition file for 'mocha')*
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/parser')*

------
https://chatgpt.com/codex/tasks/task_e_68559c85086c8324bde2f861fea92c3e