### PR TITLE
Add ungrouped tabs view

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Tabstronaut excels in tab management for VS Code by enabling users to archive an
   - Effortlessly reorder tabs or entire groups and give them colors or timestamps to keep everything tidy.
 - Manage ungrouped tabs automatically
   - View all currently open tabs that aren't in a group and drag them into groups with ease.
-  - The ungrouped section stays pinned to the bottom of the Tabstronaut view.
+  - The ungrouped section appears as its own panel pinned to the bottom of the Tabstronaut view.
 - Share and revisit your workspaces
   - Save tab groups for later, export them to share, or bring back archived sets whenever inspiration strikes.
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Tabstronaut excels in tab management for VS Code by enabling users to archive an
   - Effortlessly reorder tabs or entire groups and give them colors or timestamps to keep everything tidy.
 - Manage ungrouped tabs automatically
   - View all currently open tabs that aren't in a group and drag them into groups with ease.
+  - The ungrouped section stays pinned to the bottom of the Tabstronaut view.
 - Share and revisit your workspaces
   - Save tab groups for later, export them to share, or bring back archived sets whenever inspiration strikes.
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ Tabstronaut excels in tab management for VS Code by enabling users to archive an
   - Collect your current or all open tabs into organized groups with a single click.
 - Drag-and-drop mastery
   - Effortlessly reorder tabs or entire groups and give them colors or timestamps to keep everything tidy.
+- Manage ungrouped tabs automatically
+  - View all currently open tabs that aren't in a group and drag them into groups with ease.
 - Share and revisit your workspaces
-  - Save tab groups for later, export them to share, or bring back archived sets whenever inspiration strikes. 
+  - Save tab groups for later, export them to share, or bring back archived sets whenever inspiration strikes.
 
 ## Tips
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,6 @@ Tabstronaut excels in tab management for VS Code by enabling users to archive an
   - Collect your current or all open tabs into organized groups with a single click.
 - Drag-and-drop mastery
   - Effortlessly reorder tabs or entire groups and give them colors or timestamps to keep everything tidy.
-- Manage ungrouped tabs automatically
-  - View all currently open tabs that aren't in a group and drag them into groups with ease.
-  - The ungrouped section appears as its own panel pinned to the bottom of the Tabstronaut view.
 - Share and revisit your workspaces
   - Save tab groups for later, export them to share, or bring back archived sets whenever inspiration strikes.
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -161,6 +161,12 @@
         {
           "id": "tabstronaut",
           "name": "Tab Groups"
+        },
+        {
+          "id": "tabstronautUngrouped",
+          "name": "Ungrouped Tabs",
+          "visibility": "collapsed",
+          "priority": 100
         }
       ]
     },

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import * as path from "path";
 import { TabstronautDataProvider } from "./tabstronautDataProvider";
+import { UngroupedProvider } from "./ungroupedProvider";
 import { Group } from "./models/Group";
 import { showConfirmation } from "./utils";
 import { handleOpenTab, openFileSmart } from "./fileOperations";
@@ -66,6 +67,13 @@ export function activate(context: vscode.ExtensionContext) {
 
   const treeView = vscode.window.createTreeView("tabstronaut", {
     treeDataProvider: treeDataProvider,
+    showCollapseAll: false,
+    dragAndDropController: treeDataProvider,
+  });
+
+  const ungroupedProvider = new UngroupedProvider(treeDataProvider);
+  vscode.window.createTreeView("tabstronautUngrouped", {
+    treeDataProvider: ungroupedProvider,
     showCollapseAll: false,
     dragAndDropController: treeDataProvider,
   });

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -26,6 +26,10 @@ export function activate(context: vscode.ExtensionContext) {
 
   treeDataProvider = new TabstronautDataProvider(context.workspaceState);
 
+  vscode.window.tabGroups.onDidChangeTabs(() => {
+    treeDataProvider.refreshUngroupedTabs();
+  });
+
   treeDataProvider.onGroupAutoDeleted = (group: Group) => {
     const index = treeDataProvider.getGroupIndex(group.id);
     const prevId = treeDataProvider.getGroupIdByIndex(index - 1);

--- a/extension/src/models/Group.ts
+++ b/extension/src/models/Group.ts
@@ -7,8 +7,15 @@ export class Group extends vscode.TreeItem {
     id: string;
     creationTime: Date;
     colorName: string;
+    isPinned: boolean;
 
-    constructor(label: string, id: string = '', creationTime: Date = new Date(), colorName?: string) {
+    constructor(
+        label: string,
+        id: string = '',
+        creationTime: Date = new Date(),
+        colorName?: string,
+        isPinned = false,
+    ) {
         super(label, vscode.TreeItemCollapsibleState.Collapsed);
         this.contextValue = 'group';
         this.id = id;
@@ -16,6 +23,7 @@ export class Group extends vscode.TreeItem {
         this.description = generateRelativeTime(this.creationTime);
         this.colorName = colorName || COLORS[Math.abs(generateColorHash(this.id)) % COLORS.length];
         this.iconPath = new vscode.ThemeIcon('circle-filled', new vscode.ThemeColor(this.colorName));
+        this.isPinned = isPinned;
     }
 
     createTabItem(filePath: string): TabItem {

--- a/extension/src/tabstronautDataProvider.ts
+++ b/extension/src/tabstronautDataProvider.ts
@@ -391,8 +391,11 @@ export class TabstronautDataProvider
     } else {
       result.push(...groups);
     }
-    result.push(this.ungroupedGroup);
     return Promise.resolve(result);
+  }
+
+  public getUngroupedItems(): vscode.TreeItem[] {
+    return this.ungroupedGroup.items;
   }
 
   getParent(element: Group): vscode.ProviderResult<Group> {

--- a/extension/src/tabstronautDataProvider.ts
+++ b/extension/src/tabstronautDataProvider.ts
@@ -33,6 +33,7 @@ export class TabstronautDataProvider
   > = this._onDidChangeTreeData.event;
   private groupsMap: Map<string, Group> = new Map();
   private refreshIntervalId?: NodeJS.Timeout;
+  private ungroupedGroup: Group;
 
   constructor(private workspaceState: vscode.Memento) {
     const groupData = this.workspaceState.get<{
@@ -54,6 +55,11 @@ export class TabstronautDataProvider
       this.groupsMap.set(id, newGroup);
     }
 
+    this.ungroupedGroup = new Group("Ungrouped Tabs", "ungrouped");
+    this.ungroupedGroup.contextValue = "ungrouped";
+    this.ungroupedGroup.description = "";
+    this.refreshUngroupedTabs();
+
     this.refreshIntervalId = setInterval(
       () => this.refreshCreationTimes(),
       300000
@@ -65,9 +71,11 @@ export class TabstronautDataProvider
     dataTransfer: vscode.DataTransfer,
     token: vscode.CancellationToken
   ): Promise<void> {
-    const ids = source.map((item) => {
-      return item instanceof Group ? `group:${item.id}` : `tab:${item.id}`;
-    });
+    const ids = source
+      .filter((item) => !(item instanceof Group && item.id === this.ungroupedGroup.id))
+      .map((item) => {
+        return item instanceof Group ? `group:${item.id}` : `tab:${item.id}`;
+      });
 
     dataTransfer.set(
       "application/vnd.code.tree.tabstronaut",
@@ -130,7 +138,13 @@ export class TabstronautDataProvider
         const draggedGroup = this.groupsMap.get(groupId);
         const targetGroup = target instanceof Group ? target : undefined;
 
-        if (!draggedGroup || !targetGroup || draggedGroup.id === targetGroup.id) {
+        if (
+          !draggedGroup ||
+          !targetGroup ||
+          draggedGroup.id === targetGroup.id ||
+          draggedGroup.id === this.ungroupedGroup.id ||
+          targetGroup.id === this.ungroupedGroup.id
+        ) {
           return;
         }
 
@@ -156,7 +170,7 @@ export class TabstronautDataProvider
 
       if (id.startsWith("tab:") && target instanceof Group) {
         const tabId = id.replace("tab:", "");
-        const sourceGroup = Array.from(this.groupsMap.values()).find((g) =>
+        const sourceGroup = [...this.groupsMap.values(), this.ungroupedGroup].find((g) =>
           g.items.some((i) => i.id === tabId)
         );
 
@@ -196,25 +210,31 @@ export class TabstronautDataProvider
 
         sourceGroup.items = sourceGroup.items.filter((i) => i.id !== tabId);
 
-        if (wasLastTab) {
+        if (wasLastTab && sourceGroup.id !== this.ungroupedGroup.id) {
           if (this.onGroupAutoDeleted && backupGroup) {
             this.onGroupAutoDeleted(backupGroup);
           }
           this.groupsMap.delete(sourceGroup.id);
         }
 
-        const newItem = target.createTabItem(tabPath);
-        target.items.push(newItem);
+        if (target.id !== this.ungroupedGroup.id) {
+          const newItem = target.createTabItem(tabPath);
+          target.items.push(newItem);
+        }
 
-        this.refresh();
+        this.refreshUngroupedTabs();
         await this.updateWorkspaceState();
 
-        showConfirmation(
-          `Moved '${tab.label}' to Tab Group '${target.label}'.`
-        );
+        if (target.id !== this.ungroupedGroup.id) {
+          showConfirmation(
+            `Moved '${tab.label}' to Tab Group '${target.label}'.`
+          );
+        } else {
+          showConfirmation(`Removed '${tab.label}' from Tab Group.`);
+        }
       } else if (id.startsWith("tab:") && target instanceof vscode.TreeItem && target.contextValue === "tab") {
         const tabId = id.replace("tab:", "");
-        const sourceGroup = Array.from(this.groupsMap.values()).find((g) =>
+        const sourceGroup = [...this.groupsMap.values(), this.ungroupedGroup].find((g) =>
           g.items.some((i) => i.id === tabId)
         );
         const draggedTab = sourceGroup?.items.find((i) => i.id === tabId) as
@@ -225,7 +245,7 @@ export class TabstronautDataProvider
         }
 
         const targetTabId = target.id as string;
-        const targetGroup = Array.from(this.groupsMap.values()).find((g) =>
+        const targetGroup = [...this.groupsMap.values(), this.ungroupedGroup].find((g) =>
           g.items.some((i) => i.id === targetTabId)
         );
         if (!targetGroup) {
@@ -236,17 +256,20 @@ export class TabstronautDataProvider
 
         const draggedPath = draggedTab.resourceUri?.fsPath || "";
         const normalizedDragged = generateNormalizedPath(draggedPath);
-        const existingItem = targetGroup.items.find(
-          (item) =>
-            generateNormalizedPath(item.resourceUri?.fsPath || "") ===
-            normalizedDragged
-        );
-
-        if (existingItem && targetGroup !== sourceGroup) {
-          vscode.window.showWarningMessage(
-            `${path.basename(draggedPath)} is already in this Tab Group.`
+        let existingItem: TabItem | undefined;
+        if (targetGroup.id !== this.ungroupedGroup.id) {
+          existingItem = targetGroup.items.find(
+            (item) =>
+              generateNormalizedPath(item.resourceUri?.fsPath || "") ===
+              normalizedDragged
           );
-          continue;
+
+          if (existingItem && targetGroup !== sourceGroup) {
+            vscode.window.showWarningMessage(
+              `${path.basename(draggedPath)} is already in this Tab Group.`
+            );
+            continue;
+          }
         }
 
         const wasLastTab = sourceGroup.items.length === 1;
@@ -263,7 +286,7 @@ export class TabstronautDataProvider
 
         sourceGroup.items = sourceGroup.items.filter((i) => i.id !== tabId);
 
-        if (wasLastTab) {
+        if (wasLastTab && sourceGroup.id !== this.ungroupedGroup.id) {
           if (this.onGroupAutoDeleted && backupGroup) {
             this.onGroupAutoDeleted(backupGroup);
           }
@@ -273,20 +296,22 @@ export class TabstronautDataProvider
         if (targetGroup === sourceGroup) {
           const adjustedIndex = targetIndex;
           targetGroup.items.splice(adjustedIndex, 0, draggedTab);
-        } else {
+        } else if (targetGroup.id !== this.ungroupedGroup.id) {
           const newItem = targetGroup.createTabItem(draggedPath);
           targetGroup.items.splice(targetIndex, 0, newItem);
         }
 
-        this.refresh();
+        this.refreshUngroupedTabs();
         await this.updateWorkspaceState();
 
         if (targetGroup === sourceGroup) {
           showConfirmation(`Reordered '${draggedTab.label}'.`);
-        } else {
+        } else if (targetGroup.id !== this.ungroupedGroup.id) {
           showConfirmation(
             `Moved '${draggedTab.label}' to Tab Group '${targetGroup.label}'.`
           );
+        } else {
+          showConfirmation(`Removed '${draggedTab.label}' from Tab Group.`);
         }
       }
     }
@@ -296,6 +321,39 @@ export class TabstronautDataProvider
     this.groupsMap.forEach((group) => {
       group.description = generateRelativeTime(group.creationTime);
     });
+    this.refresh();
+  }
+
+  public refreshUngroupedTabs(): void {
+    const allTabs = vscode.window.tabGroups.all.flatMap((g) => g.tabs);
+    const seen = new Set<string>();
+    const ungrouped: string[] = [];
+
+    for (const tab of allTabs) {
+      if (!tab.input || typeof tab.input !== "object" || !("uri" in tab.input)) {
+        continue;
+      }
+      const uri = (tab.input as any).uri as vscode.Uri;
+      if (!(uri instanceof vscode.Uri) || uri.scheme !== "file") {
+        continue;
+      }
+      const filePath = uri.fsPath;
+      const normalized = generateNormalizedPath(filePath);
+      if (seen.has(normalized)) {
+        continue;
+      }
+      seen.add(normalized);
+      const inGroup = Array.from(this.groupsMap.values()).some((g) =>
+        g.containsFile(filePath)
+      );
+      if (!inGroup) {
+        ungrouped.push(filePath);
+      }
+    }
+
+    this.ungroupedGroup.items = ungrouped.map((p) =>
+      this.ungroupedGroup.createTabItem(p)
+    );
     this.refresh();
   }
 
@@ -327,11 +385,14 @@ export class TabstronautDataProvider
     }
 
     const groups = Array.from(this.groupsMap.values());
+    const result: (Group | vscode.TreeItem)[] = [];
     if (groups.length === 0) {
-      return Promise.resolve([this.createInstructionItem()]);
+      result.push(this.createInstructionItem());
+    } else {
+      result.push(...groups);
     }
-
-    return Promise.resolve(groups);
+    result.push(this.ungroupedGroup);
+    return Promise.resolve(result);
   }
 
   getParent(element: Group): vscode.ProviderResult<Group> {
@@ -472,6 +533,7 @@ export class TabstronautDataProvider
     }
 
     await this.updateWorkspaceState();
+    this.refreshUngroupedTabs();
     this._onDidChangeTreeData.fire();
   }
 
@@ -505,6 +567,7 @@ export class TabstronautDataProvider
       );
     });
 
+    this.refreshUngroupedTabs();
     this._onDidChangeTreeData.fire(undefined);
   }
 
@@ -540,6 +603,7 @@ export class TabstronautDataProvider
   async deleteGroup(groupId: string): Promise<void> {
     this.groupsMap.delete(groupId);
     await this.updateWorkspaceState();
+    this.refreshUngroupedTabs();
     this._onDidChangeTreeData.fire();
   }
 
@@ -637,6 +701,7 @@ export class TabstronautDataProvider
       }
     });
     await this.workspaceState.update("tabGroups", groupData);
+    this.refreshUngroupedTabs();
     this._onDidChangeTreeData.fire();
   }
 

--- a/extension/src/ungroupedProvider.ts
+++ b/extension/src/ungroupedProvider.ts
@@ -1,0 +1,17 @@
+import * as vscode from "vscode";
+import { TabstronautDataProvider } from "./tabstronautDataProvider";
+
+export class UngroupedProvider implements vscode.TreeDataProvider<vscode.TreeItem> {
+  constructor(private mainProvider: TabstronautDataProvider) {}
+
+  readonly onDidChangeTreeData: vscode.Event<vscode.TreeItem | undefined> =
+    this.mainProvider.onDidChangeTreeData;
+
+  getTreeItem(element: vscode.TreeItem): vscode.TreeItem {
+    return element;
+  }
+
+  getChildren(): vscode.ProviderResult<vscode.TreeItem[]> {
+    return Promise.resolve(this.mainProvider.getUngroupedItems());
+  }
+}

--- a/extension/src/ungroupedProvider.ts
+++ b/extension/src/ungroupedProvider.ts
@@ -1,11 +1,15 @@
 import * as vscode from "vscode";
 import { TabstronautDataProvider } from "./tabstronautDataProvider";
 
-export class UngroupedProvider implements vscode.TreeDataProvider<vscode.TreeItem> {
+export class UngroupedProvider
+  implements vscode.TreeDataProvider<vscode.TreeItem>
+{
   constructor(private mainProvider: TabstronautDataProvider) {}
 
   readonly onDidChangeTreeData: vscode.Event<vscode.TreeItem | undefined> =
-    this.mainProvider.onDidChangeTreeData;
+    this.mainProvider.onDidChangeTreeData as vscode.Event<
+      vscode.TreeItem | undefined
+    >;
 
   getTreeItem(element: vscode.TreeItem): vscode.TreeItem {
     return element;

--- a/extension/test/suite/ungroupedTabs.test.ts
+++ b/extension/test/suite/ungroupedTabs.test.ts
@@ -1,0 +1,77 @@
+import { strictEqual } from 'assert';
+import * as vscode from 'vscode';
+import { TabstronautDataProvider } from '../../src/tabstronautDataProvider';
+
+class MockMemento implements vscode.Memento {
+  private store: Record<string, any>;
+  constructor(initial: Record<string, any> = {}) {
+    this.store = initial;
+  }
+  keys(): readonly string[] {
+    throw new Error('Method not implemented.');
+  }
+  get<T>(key: string, defaultValue?: T): T {
+    if (key in this.store) {
+      return this.store[key] as T;
+    }
+    return defaultValue as T;
+  }
+  update(key: string, value: any): Thenable<void> {
+    this.store[key] = value;
+    return Promise.resolve();
+  }
+}
+
+describe('TabstronautDataProvider.refreshUngroupedTabs', () => {
+  let origTabGroups: any;
+
+  beforeEach(() => {
+    origTabGroups = vscode.window.tabGroups;
+  });
+
+  afterEach(() => {
+    Object.defineProperty(vscode.window, 'tabGroups', { value: origTabGroups, configurable: true });
+  });
+
+  it('collects open tabs not in groups', () => {
+    const uri1 = vscode.Uri.file('/tmp/a.txt');
+    const uri2 = vscode.Uri.file('/tmp/b.txt');
+    const tab1 = { input: { uri: uri1 } } as any;
+    const tab2 = { input: { uri: uri2 } } as any;
+
+    Object.defineProperty(vscode.window, 'tabGroups', {
+      value: { all: [{ tabs: [tab1, tab2] }] },
+      configurable: true,
+    });
+
+    const provider = new TabstronautDataProvider(new MockMemento({}));
+    provider.clearRefreshInterval();
+
+    const items = provider.getUngroupedItems();
+    strictEqual(items.length, 2);
+    strictEqual(items[0].resourceUri?.fsPath, '/tmp/a.txt');
+    strictEqual(items[1].resourceUri?.fsPath, '/tmp/b.txt');
+  });
+
+  it('removes tab when added to group', async () => {
+    const uri1 = vscode.Uri.file('/tmp/a.txt');
+    const uri2 = vscode.Uri.file('/tmp/b.txt');
+    const tab1 = { input: { uri: uri1 } } as any;
+    const tab2 = { input: { uri: uri2 } } as any;
+
+    Object.defineProperty(vscode.window, 'tabGroups', {
+      value: { all: [{ tabs: [tab1, tab2] }] },
+      configurable: true,
+    });
+
+    const provider = new TabstronautDataProvider(new MockMemento({}));
+    const groupId = await provider.addGroup('G1');
+    await provider.addToGroup(groupId!, '/tmp/a.txt');
+    provider.refreshUngroupedTabs();
+    provider.clearRefreshInterval();
+
+    const items = provider.getUngroupedItems();
+    strictEqual(items.length, 1);
+    strictEqual(items[0].resourceUri?.fsPath, '/tmp/b.txt');
+  });
+});


### PR DESCRIPTION
## Summary
- show ungrouped tabs below saved groups
- keep ungrouped list up to date when open tabs change
- allow dragging tabs between ungrouped and grouped sections
- document feature in README

## Testing
- `npm test` *(fails: Cannot find type definition file for 'mocha')*

------
https://chatgpt.com/codex/tasks/task_e_6855ab07ea288324b11912b5e09ac96f