### PR TITLE
Add drag drop to create new Tab Group

### DIFF
--- a/extension/test/suite/dragAndDropAdd.test.ts
+++ b/extension/test/suite/dragAndDropAdd.test.ts
@@ -71,3 +71,28 @@ describe('TabstronautDataProvider addToGroup duplicate handling', () => {
     strictEqual(group?.items.length, 1);
   });
 });
+
+describe('TabstronautDataProvider handleDrop new group on empty space', () => {
+  it('creates new group with defaults when dropping tab to empty area', async () => {
+    const provider = new TabstronautDataProvider(new MockMemento({}));
+    const groupId = await provider.addGroup('G1');
+    const group = provider.getGroup('G1')!;
+    await provider.addToGroup(groupId!, '/tmp/file1');
+    const tabId = group.items[0].id;
+
+    const dragData = new vscode.DataTransfer();
+    dragData.set(
+      'application/vnd.code.tree.tabstronaut',
+      new vscode.DataTransferItem(`tab:${tabId}`)
+    );
+
+    await provider.handleDrop(undefined, dragData, new vscode.CancellationTokenSource().token);
+    provider.clearRefreshInterval();
+
+    const groups = provider.getGroups();
+    strictEqual(groups.length, 1);
+    strictEqual(groups[0].label, 'Group 2');
+    strictEqual(groups[0].items.length, 1);
+    strictEqual(groups[0].items[0].resourceUri?.fsPath, '/tmp/file1');
+  });
+});


### PR DESCRIPTION
## Summary
- create new Tab Group when a tab is dropped on empty space
- test that dropping a tab on empty area creates a default-named group

## Testing
- `npm test` *(fails: Failed to run tests due to missing display / SIGSEGV)*

------
https://chatgpt.com/codex/tasks/task_e_6855bc23266483248615546f5271e65c