### PR TITLE
Add undo for closing and restoring tabs

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Tabstronaut extension will be documented in this file
 
 - Dropping a tab onto empty space now creates a new Tab Group with the next default name and color.
 - Added `tabstronaut.newTabGroupPosition` setting to control where new groups are inserted, defaulting to the bottom of the list.
+- Can undo restoring tabs and closing all tabs.
 
 ## [1.3.2]
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -145,6 +145,12 @@
         "title": "Undo Delete",
         "category": "Tabstronaut",
         "icon": "$(discard)"
+      },
+      {
+        "command": "tabstronaut.undoCloseEditors",
+        "title": "Undo Close Editors",
+        "category": "Tabstronaut",
+        "icon": "$(discard)"
       }
     ],
     "viewsContainers": {
@@ -175,6 +181,11 @@
         {
           "command": "tabstronaut.undoDelete",
           "when": "view == tabstronaut && tabstronaut:canUndoDelete",
+          "group": "navigation@-1"
+        },
+        {
+          "command": "tabstronaut.undoCloseEditors",
+          "when": "view == tabstronaut && tabstronaut:canUndoClose",
           "group": "navigation@-1"
         },
         {


### PR DESCRIPTION
## Summary
- add `Undo Close Editors` command
- show undo button when closing editors or restoring tab groups
- reopen closed editors if undone

## Testing
- `npm test` *(fails: Cannot find type definition file for 'mocha')*

------
https://chatgpt.com/codex/tasks/task_e_6855c837410883248b7d4420af2ed18b