### PR TITLE
Graceful reload if ungrouped view is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,6 @@ Your changes will be saved automatically.
 
 ## Known Issues
 
-After upgrading to **v1.3.2**, VS Code may display `No view is registered with id: tabstronautUngrouped` until the window is reloaded. Selecting **Reload** when prompted resolves the issue.
-
 If you encounter any other problem, please open an [Issue](https://github.com/jhhtaylor/tabstronaut/issues) on the GitHub repository.
 
 ## Release Notes

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Your changes will be saved automatically.
 
 ## Known Issues
 
-If you encounter any other problem, please open an [Issue](https://github.com/jhhtaylor/tabstronaut/issues) on the GitHub repository.
+After upgrading to **v1.3.2**, VS Code may display `No view is registered with id: tabstronautUngrouped` until the window is reloaded. Selecting **Reload** when prompted resolves the issue. Version **1.3.3** shows this prompt automatically if needed.
 
 ## Release Notes
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ Your changes will be saved automatically.
 
 ## Known Issues
 
-There are no known issues at the moment. If you encounter a bug, please open an [Issue](https://github.com/jhhtaylor/tabstronaut/issues) on the GitHub repository.
+After upgrading to **v1.3.2**, VS Code may display `No view is registered with id: tabstronautUngrouped` until the window is reloaded. Selecting **Reload** when prompted resolves the issue.
+
+If you encounter any other problem, please open an [Issue](https://github.com/jhhtaylor/tabstronaut/issues) on the GitHub repository.
 
 ## Release Notes
 

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Tabstronaut extension will be documented in this file.
 
+## [1.3.3]
+
+- Reload VS Code automatically if the Ungrouped Tabs view fails to register after upgrading.
+
 ## [1.3.2]
 
 - New Ungrouped Tabs section.

--- a/extension/package.json
+++ b/extension/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/jhhtaylor/tabstronaut/issues",
     "email": "jhhtaylor@gmail.com"
   },
-  "version": "1.3.2",
+  "version": "1.3.3",
   "engines": {
     "vscode": "^1.99.0"
   },

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -72,11 +72,31 @@ export function activate(context: vscode.ExtensionContext) {
   });
 
   const ungroupedProvider = new UngroupedProvider(treeDataProvider);
-  vscode.window.createTreeView("tabstronautUngrouped", {
-    treeDataProvider: ungroupedProvider,
-    showCollapseAll: false,
-    dragAndDropController: treeDataProvider,
-  });
+  try {
+    vscode.window.createTreeView("tabstronautUngrouped", {
+      treeDataProvider: ungroupedProvider,
+      showCollapseAll: false,
+      dragAndDropController: treeDataProvider,
+    });
+  } catch (err) {
+    if (
+      err instanceof Error &&
+      err.message.includes("No view is registered with id: tabstronautUngrouped")
+    ) {
+      vscode.window
+        .showInformationMessage(
+          "Tabstronaut needs to reload VS Code to enable Ungrouped Tabs.",
+          "Reload"
+        )
+        .then((selection) => {
+          if (selection === "Reload") {
+            vscode.commands.executeCommand("workbench.action.reloadWindow");
+          }
+        });
+    } else {
+      throw err;
+    }
+  }
 
   let recentlyDeletedGroup:
     | (Group & { index: number; previousGroupId?: string })


### PR DESCRIPTION
## Summary
- catch errors when registering the ungrouped tabs view and prompt the user to reload
- document the reload requirement in Known Issues

## Testing
- `npm test` *(fails: Cannot find type definition file for 'mocha')*

------
https://chatgpt.com/codex/tasks/task_e_6855d5410e8083248b9c51cc2634fb82