### PR TITLE
Restore active tab only when auto-remove is enabled

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -508,12 +508,17 @@
         "tabstronaut.autoCloseOnRestore": {
           "type": "boolean",
           "default": false,
-          "description": "Close all currently open tabs before restoring a Tab Group for clean context switching."
+          "description": "Close all currently open tabs before restoring a Tab Group for clean context switching. Cannot be used together with Automatically remove closed tabs."
         },
         "tabstronaut.showConfirmationMessages": {
           "type": "boolean",
           "default": false,
           "description": "Show confirmation messages after adding tabs to groups."
+        },
+        "tabstronaut.autoRemoveClosedTabs": {
+          "type": "boolean",
+          "default": false,
+          "description": "Automatically remove closed tabs from any Tab Groups that include them. Cannot be used together with Close tabs before restoring groups. When enabled, restoring a Tab Group reopens its last active tab."
         },
         "tabstronaut.promptForGroupDetails": {
           "type": "boolean",

--- a/extension/src/fileOperations.ts
+++ b/extension/src/fileOperations.ts
@@ -33,10 +33,13 @@ export async function handleOpenTab(item: any, fromButton: boolean) {
   }
 }
 
-export async function openFileSmart(filePath: string): Promise<void> {
+export async function openFileSmart(
+  filePath: string,
+  options?: { preserveFocus?: boolean }
+): Promise<void> {
   const uri = vscode.Uri.file(filePath);
   try {
-    if (await revealExistingTab(uri)) {
+    if (await revealExistingTab(uri, options)) {
       return;
     }
 
@@ -48,7 +51,10 @@ export async function openFileSmart(filePath: string): Promise<void> {
       );
     } else {
       const document = await vscode.workspace.openTextDocument(uri);
-      await vscode.window.showTextDocument(document, { preview: false });
+      await vscode.window.showTextDocument(document, {
+        preview: false,
+        preserveFocus: options?.preserveFocus,
+      });
     }
   } catch {
     vscode.window.showErrorMessage(
@@ -57,7 +63,10 @@ export async function openFileSmart(filePath: string): Promise<void> {
   }
 }
 
-async function revealExistingTab(uri: vscode.Uri): Promise<boolean> {
+async function revealExistingTab(
+  uri: vscode.Uri,
+  options?: { preserveFocus?: boolean }
+): Promise<boolean> {
   for (const group of vscode.window.tabGroups.all) {
     for (const tab of group.tabs) {
       const input = (tab as any).input;
@@ -78,6 +87,7 @@ async function revealExistingTab(uri: vscode.Uri): Promise<boolean> {
           await vscode.window.showTextDocument(document, {
             viewColumn: group.viewColumn,
             preview: false,
+            preserveFocus: options?.preserveFocus,
           });
         }
         return true;

--- a/extension/src/groupOperations.ts
+++ b/extension/src/groupOperations.ts
@@ -438,6 +438,13 @@ export async function addAllOpenTabsToGroup(
     }
   }
 
+  const activeEditor = vscode.window.activeTextEditor;
+  if (activeEditor && activeEditor.document.uri.scheme === 'file') {
+    await treeDataProvider.updateActiveFileForGroups(
+      activeEditor.document.uri.fsPath
+    );
+  }
+
   showConfirmation(`Added ${count} open tab(s) to Tab Group '${group.label}'.`);
 }
 

--- a/extension/src/models/Group.ts
+++ b/extension/src/models/Group.ts
@@ -8,6 +8,7 @@ export class Group extends vscode.TreeItem {
     creationTime: Date;
     colorName: string;
     isPinned: boolean;
+    activeFilePath?: string;
 
     constructor(
         label: string,


### PR DESCRIPTION
## Summary
- only restore a group's saved active editor when automatic closed-tab removal is turned on
- clarify the auto-remove setting description to explain when the active editor is restored

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914d75db2cc8324acfd4984a538d8ce)